### PR TITLE
Add Jenkins pipeline

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
           deleteDir()
           unstash 'source'
           script {
-            docker.image("node:${NODE_VERSION}-alpine").inside(){
+            docker.image("node:${NODE_VERSION}").inside(){
               dir("${BASE_DIR}"){
                 sh(label: 'Build NodeJS', script: 'yarn install')
                 sh(label: 'Lint', script: 'yarn lint')
@@ -68,7 +68,7 @@ pipeline {
               deleteDir()
               unstash 'source'
               script {
-                docker.image("node:${NODE_VERSION}-alpine").inside(){
+                docker.image("node:${NODE_VERSION}").inside(){
                   dir("${BASE_DIR}"){
                     sh(label: 'Yarn Install', script: 'yarn install')
                     sh(label: 'Yarn Build', script: 'yarn test:ci')
@@ -94,7 +94,7 @@ pipeline {
               deleteDir()
               unstash 'compiledSource'
               script {
-                docker.image("node:${NODE_VERSION}-alpine").inside(){
+                docker.image("node:${NODE_VERSION}").inside(){
                   dir("${BASE_DIR}"){
                     sh(label: 'Yarn Build', script: 'yarn test:ci')
                   }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
   environment {
     REPO = 'ctags-langserver'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
+    NODE_VERSION="10"
     YARN_GPG = 'no'
   }
   options {
@@ -42,7 +43,7 @@ pipeline {
           deleteDir()
           unstash 'source'
           script {
-            docker.image("node:10").inside(){
+            docker.image("node:${NODE_VERSION}-alpine").inside(){
               dir("${BASE_DIR}"){
                 sh(label: 'Build NodeJS', script: 'yarn install')
                 sh(label: 'Lint', script: 'yarn lint')
@@ -67,7 +68,7 @@ pipeline {
               deleteDir()
               unstash 'source'
               script {
-                docker.image("node:10").inside(){
+                docker.image("node:${NODE_VERSION}-alpine").inside(){
                   dir("${BASE_DIR}"){
                     sh(label: 'Yarn Install', script: 'yarn install')
                     sh(label: 'Yarn Build', script: 'yarn test:ci')
@@ -91,15 +92,40 @@ pipeline {
           steps {
             withGithubNotify(context: 'Linux tests') {
               deleteDir()
-              unstash 'source'
+              unstash 'compiledSource'
               script {
-                docker.image("node:10").inside(){
+                docker.image("node:${NODE_VERSION}-alpine").inside(){
                   dir("${BASE_DIR}"){
-                    sh(label: 'Yarn Install', script: 'yarn install')
                     sh(label: 'Yarn Build', script: 'yarn test:ci')
                   }
                 }
               }
+            }
+          }
+          post {
+            always {
+              junit(allowEmptyResults: true, keepLongStdio: true, testResults: "**/${JEST_JUNIT_OUTPUT_NAME}")
+            }
+          }
+        }
+        stage('Windows') {
+          agent { label 'windows-2019-immutable' }
+          options { skipDefaultCheckout() }
+          environment {
+            PATH="${PATH};C:\\Program Files\\nodejs"
+            JEST_JUNIT_OUTPUT_NAME="TEST-unit-windows.xml"
+          }
+          steps {
+            deleteDir()
+            unstash 'source'
+            dir(BASE_DIR) {
+              powershell label: 'Install tools', script: ".\\.ci\\scripts\\windows\\install-node.ps1"
+              bat label: 'Tool versions', script: '''
+                npm --version
+                node --version
+              '''
+              bat label: 'NPM Install', script: 'npm install'
+              bat label: 'NPM Tests', script: 'npm run test:ci'
             }
           }
           post {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -125,7 +125,7 @@ pipeline {
                 node --version
               '''
               bat label: 'NPM Install', script: 'npm install'
-              bat label: 'NPM Tests', script: 'npm run test:ci'
+              bat label: 'NPM Tests', script: 'npm run test:ci:windows'
             }
           }
           post {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -67,13 +67,9 @@ pipeline {
             withGithubNotify(context: 'OSX tests') {
               deleteDir()
               unstash 'source'
-              script {
-                docker.image("node:${NODE_VERSION}").inside(){
-                  dir("${BASE_DIR}"){
-                    sh(label: 'Yarn Install', script: 'yarn install')
-                    sh(label: 'Yarn Build', script: 'yarn test:ci')
-                  }
-                }
+              dir("${BASE_DIR}"){
+                sh(label: 'Yarn Install', script: 'yarn install')
+                sh(label: 'Yarn Build', script: 'yarn test:ci')
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -41,10 +41,9 @@ pipeline {
         withGithubNotify(context: 'Lint') {
           deleteDir()
           unstash 'source'
-          dir("${BASE_DIR}") {
-            script {
-              docker.image("node:10").inside("-v ${WORKSPACE}/${BASE_DIR}:/app"){
-                env.HOME = "${WORKSPACE}"
+          script {
+            docker.image("node:10").inside(){
+              dir("${BASE_DIR}"){
                 sh(label: 'Build NodeJS', script: 'cd /app && yarn install')
                 sh(label: 'Lint', script: 'cd /app && yarn lint')
               }
@@ -124,11 +123,10 @@ pipeline {
         withGithubNotify(context: 'Publish to NPM') {
           deleteDir()
           unstash 'compiledSource'
-          dir("${BASE_DIR}") {
-            script {
-              docker.image("node:10").inside("-v ${WORKSPACE}/${BASE_DIR}:/app"){
-                env.HOME = "${WORKSPACE}"
-                sh(label: 'Lint', script: 'cd /app && yarn pub')
+          script {
+            docker.image("node:10").inside(){
+              dir("${BASE_DIR}") {
+                sh(label: 'Lint', script: 'yarn pub')
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -61,18 +61,17 @@ pipeline {
           options { skipDefaultCheckout() }
           environment {
             HOME = "${env.WORKSPACE}"
+            JEST_JUNIT_OUTPUT_NAME="TEST-unit-osx.xml"
           }
           steps {
             withGithubNotify(context: 'OSX tests') {
               deleteDir()
               unstash 'source'
-              dir("${BASE_DIR}"){
-                script {
-                  docker.image("node:10").inside("-v ${WORKSPACE}/${BASE_DIR}:/app"){
-                    env.HOME = "${WORKSPACE}"
-                    env.JEST_JUNIT_OUTPUT_NAME = "TEST-unit-osx.xml"
-                    sh(label: 'Yarn Install', script: 'cd /app && yarn install')
-                    sh(label: 'Yarn Build', script: 'cd /app && yarn test:ci')
+              script {
+                docker.image("node:10").inside(){
+                  dir("${BASE_DIR}"){
+                    sh(label: 'Yarn Install', script: 'yarn install')
+                    sh(label: 'Yarn Build', script: 'yarn test:ci')
                   }
                 }
               }
@@ -88,18 +87,17 @@ pipeline {
           options { skipDefaultCheckout() }
           environment {
             HOME = "${env.WORKSPACE}"
+            JEST_JUNIT_OUTPUT_NAME="TEST-unit-linux.xml"
           }
           steps {
             withGithubNotify(context: 'Linux tests') {
               deleteDir()
               unstash 'source'
-              dir("${BASE_DIR}") {
-                script {
-                  docker.image("node:10").inside("-v ${WORKSPACE}/${BASE_DIR}:/app"){
-                    env.HOME = "${WORKSPACE}"
-                    env.JEST_JUNIT_OUTPUT_NAME = "TEST-unit-linux.xml"
-                    sh(label: 'Yarn Install', script: 'cd /app && yarn install')
-                    sh(label: 'Yarn Build', script: 'cd /app && yarn test:ci')
+              script {
+                docker.image("node:10").inside(){
+                  dir("${BASE_DIR}"){
+                    sh(label: 'Yarn Install', script: 'yarn install')
+                    sh(label: 'Yarn Build', script: 'yarn test:ci')
                   }
                 }
               }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
     durabilityHint('PERFORMANCE_OPTIMIZED')
   }
   parameters {
-    booleanParam(name: 'publish_to_npm', defaultValue: false, description: 'Publish to NPM.')
+    booleanParam(name: 'PUBLISH_TO_NPM', defaultValue: false, description: 'Publish to NPM.')
   }
   triggers {
     issueCommentTrigger('(?i).*jenkins\\W+run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
@@ -108,6 +108,30 @@ pipeline {
           post {
             always {
               junit(allowEmptyResults: true, keepLongStdio: true, testResults: "**/${JEST_JUNIT_OUTPUT_NAME}.xml")
+            }
+          }
+        }
+      }
+    }
+    stage('Publish to NPM') {
+      options { skipDefaultCheckout() }
+      when {
+        beforeAgent true
+        allOf {
+          tag pattern: 'v\\d+.*', comparator: 'REGEXP'
+          expression { return params.PUBLISH_TO_NPM }
+        }
+      }
+      steps {
+        withGithubNotify(context: 'Publish to NPM') {
+          deleteDir()
+          unstash 'compiledSource'
+          dir("${BASE_DIR}") {
+            script {
+              docker.image("node:10").inside("-v ${WORKSPACE}/${BASE_DIR}:/app"){
+                env.HOME = "${WORKSPACE}"
+                sh(label: 'Lint', script: 'cd /app && yarn pub')
+              }
             }
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
           }
           post {
             always {
-              junit(allowEmptyResults: true, keepLongStdio: true, testResults: "**/${JEST_JUNIT_OUTPUT_NAME}.xml")
+              junit(allowEmptyResults: true, keepLongStdio: true, testResults: "**/${JEST_JUNIT_OUTPUT_NAME}")
             }
           }
         }
@@ -104,7 +104,7 @@ pipeline {
           }
           post {
             always {
-              junit(allowEmptyResults: true, keepLongStdio: true, testResults: "**/${JEST_JUNIT_OUTPUT_NAME}.xml")
+              junit(allowEmptyResults: true, keepLongStdio: true, testResults: "**/${JEST_JUNIT_OUTPUT_NAME}")
             }
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -62,14 +62,16 @@ pipeline {
           environment {
             HOME = "${env.WORKSPACE}"
             JEST_JUNIT_OUTPUT_NAME="TEST-unit-osx.xml"
+            PATH="${HOME}/.yarn/bin:${HOME}/.config/yarn/global/node_modules/.bin:${PATH}"
+            NODE_VERSION="10.17.0"
+            NVM_DIR="${HOME}/.nvm"
           }
           steps {
             withGithubNotify(context: 'OSX tests') {
               deleteDir()
               unstash 'source'
               dir("${BASE_DIR}"){
-                sh(label: 'Yarn Install', script: 'yarn install')
-                sh(label: 'Yarn Build', script: 'yarn test:ci')
+                sh(label: 'Yarn Tests', script: ".ci/scripts/darwin/run-yarn-tests.sh ${NODE_VERSION}")
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -44,8 +44,8 @@ pipeline {
           script {
             docker.image("node:10").inside(){
               dir("${BASE_DIR}"){
-                sh(label: 'Build NodeJS', script: 'cd /app && yarn install')
-                sh(label: 'Lint', script: 'cd /app && yarn lint')
+                sh(label: 'Build NodeJS', script: 'yarn install')
+                sh(label: 'Lint', script: 'yarn lint')
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,0 +1,122 @@
+#!/usr/bin/env groovy
+
+@Library('apm@current') _
+
+pipeline {
+  agent { label 'linux && immutable' }
+  environment {
+    REPO = 'ctags-langserver'
+    BASE_DIR = "src/github.com/elastic/${env.REPO}"
+    YARN_GPG = 'no'
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '30', artifactNumToKeepStr: '20'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+  }
+  parameters {
+    booleanParam(name: 'publish_to_npm', defaultValue: false, description: 'Publish to NPM.')
+  }
+  triggers {
+    issueCommentTrigger('(?i).*jenkins\\W+run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
+  }
+  stages {
+    stage('Checkout') {
+      options { skipDefaultCheckout() }
+      steps {
+        deleteDir()
+        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
+        stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+      }
+    }
+    stage('Static Analisis') {
+      options { skipDefaultCheckout() }
+      environment {
+        HOME = "${env.WORKSPACE}"
+      }
+      steps {
+        withGithubNotify(context: 'Lint') {
+          deleteDir()
+          unstash 'source'
+          dir("${BASE_DIR}") {
+            script {
+              docker.image("node:10").inside("-v ${WORKSPACE}/${BASE_DIR}:/app"){
+                env.HOME = "${WORKSPACE}"
+                sh(label: 'Build NodeJS', script: 'cd /app && yarn install')
+                sh(label: 'Lint', script: 'cd /app && yarn lint')
+              }
+            }
+          }
+          stash allowEmpty: true, name: 'compiledSource', useDefaultExcludes: false
+        }
+      }
+    }
+    stage('Build') {
+      parallel {
+        stage('OSX') {
+          agent { label 'macosx' }
+          options { skipDefaultCheckout() }
+          environment {
+            HOME = "${env.WORKSPACE}"
+          }
+          steps {
+            withGithubNotify(context: 'OSX tests') {
+              deleteDir()
+              unstash 'source'
+              dir("${BASE_DIR}"){
+                script {
+                  docker.image("node:10").inside("-v ${WORKSPACE}/${BASE_DIR}:/app"){
+                    env.HOME = "${WORKSPACE}"
+                    env.JEST_JUNIT_OUTPUT_NAME = "TEST-unit-osx.xml"
+                    sh(label: 'Yarn Install', script: 'cd /app && yarn install')
+                    sh(label: 'Yarn Build', script: 'cd /app && yarn test:ci')
+                  }
+                }
+              }
+            }
+          }
+          post {
+            always {
+              junit(allowEmptyResults: true, keepLongStdio: true, testResults: "**/${JEST_JUNIT_OUTPUT_NAME}.xml")
+            }
+          }
+        }
+        stage('Linux') {
+          options { skipDefaultCheckout() }
+          environment {
+            HOME = "${env.WORKSPACE}"
+          }
+          steps {
+            withGithubNotify(context: 'Linux tests') {
+              deleteDir()
+              unstash 'source'
+              dir("${BASE_DIR}") {
+                script {
+                  docker.image("node:10").inside("-v ${WORKSPACE}/${BASE_DIR}:/app"){
+                    env.HOME = "${WORKSPACE}"
+                    env.JEST_JUNIT_OUTPUT_NAME = "TEST-unit-linux.xml"
+                    sh(label: 'Yarn Install', script: 'cd /app && yarn install')
+                    sh(label: 'Yarn Build', script: 'cd /app && yarn test:ci')
+                  }
+                }
+              }
+            }
+          }
+          post {
+            always {
+              junit(allowEmptyResults: true, keepLongStdio: true, testResults: "**/${JEST_JUNIT_OUTPUT_NAME}.xml")
+            }
+          }
+        }
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult()
+    }
+  }
+}

--- a/.ci/scripts/darwin/run-yarn-tests.sh
+++ b/.ci/scripts/darwin/run-yarn-tests.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euxo pipefail
+
+NODE_VERSION=${1:?"Node version is required"}
+
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.0/install.sh | bash
+
+source "${NVM_DIR}/nvm.sh"
+
+nvm --version
+
+nvm install ${NODE_VERSION}
+
+nvm use --delete-prefix ${NODE_VERSION}
+
+touch ~/.bashrc
+
+curl -o- -L https://yarnpkg.com/install.sh | bash
+
+yarn install
+
+yarn test:ci

--- a/.ci/scripts/windows/install-node.ps1
+++ b/.ci/scripts/windows/install-node.ps1
@@ -1,0 +1,8 @@
+# Abort with non zero exit code on errors
+$ErrorActionPreference = "Stop"
+
+Write-Host "Getting latest Nodejs version..."
+$Version = $(choco list nodejs --by-id-only --all) | Select-String -Pattern "nodejs $env:NODE_VERSION" | %{$_.ToString().split(" ")[1]} | sort {[version] $_} | Select-Object -Last 1
+
+Write-Host "Installing Nodejs..."
+& choco install nodejs --no-progress -y --version "$Version"

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 tsconfig.tsbuildinfo
 .vscode
 build
+test-results

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"tslint": "tslint -c tslint.json -p .",
 		"test": "jest",
 		"test:ci": "JEST_JUNIT_OUTPUT_DIR=test-results jest --ci --reporters=default --reporters='jest-junit'",
+		"test:ci:windows": "$env:JEST_JUNIT_OUTPUT_DIR = 'test-results'; jest --ci --reporters=default --reporters='jest-junit'",
 		"clean": "rimraf lib",
 		"lint": "tslint -c ./tslint.json --project .",
 		"pub": "yarn clean && yarn build && yarn publish --access=public"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"tslint": "tslint -c tslint.json -p .",
 		"test": "jest",
 		"test:ci": "JEST_JUNIT_OUTPUT_DIR=test-results jest --ci --reporters=default --reporters='jest-junit'",
-		"test:ci:windows": "$env:JEST_JUNIT_OUTPUT_DIR = 'test-results'; jest --ci --reporters=default --reporters='jest-junit'",
+		"test:ci:windows": "set JEST_JUNIT_OUTPUT_DIR=test-results && jest --ci --reporters=default --reporters='jest-junit'",
 		"clean": "rimraf lib",
 		"lint": "tslint -c ./tslint.json --project .",
 		"pub": "yarn clean && yarn build && yarn publish --access=public"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"compile": "tsc -b tsconfig.json",
 		"tslint": "tslint -c tslint.json -p .",
 		"test": "jest",
+		"test:ci": "JEST_JUNIT_OUTPUT_DIR=test-results jest --ci --reporters=default --reporters='jest-junit'",
 		"clean": "rimraf lib",
 		"lint": "tslint -c ./tslint.json --project .",
 		"pub": "yarn clean && yarn build && yarn publish --access=public"
@@ -41,6 +42,7 @@
 		"@types/mz": "0.0.32",
 		"@types/node": "^12.0.4",
 		"jest": "^24.9.0",
+		"jest-junit": "^8.0.0",
 		"ts-jest": "^24.0.2",
 		"ts-node": "7.0.1",
 		"tslint": "^5.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1893,6 +1893,16 @@ jest-jasmine2@^24.9.0:
     pretty-format "^24.9.0"
     throat "^4.0.0"
 
+jest-junit@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-8.0.0.tgz#d4f7ff67e292a5426dc60bc38694c9f77cb94178"
+  integrity sha512-cuD2XM2youMjrOxOu/7H2pLfsO8LfAG4D3WsBxd9fFyI9U0uPpmr/CORH64kbIyZ47X5x1Rbzb9ovUkAEvhEEA==
+  dependencies:
+    jest-validate "^24.0.0"
+    mkdirp "^0.5.1"
+    strip-ansi "^4.0.0"
+    xml "^1.0.1"
+
 jest-leak-detector@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz#b665dea7c77100c5c4f7dfcb153b65cf07dcf96a"
@@ -2063,7 +2073,7 @@ jest-util@^24.9.0:
     slash "^2.0.0"
     source-map "^0.6.0"
 
-jest-validate@^24.9.0:
+jest-validate@^24.0.0, jest-validate@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-24.9.0.tgz#0775c55360d173cd854e40180756d4ff52def8ab"
   integrity sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==
@@ -3813,6 +3823,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 y18n@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## What does this PR do?
It adds the Jenkins pipeline to start building this project in collaboration with the Observability Automation team.

Here we add an NPM task to run unit tests on CI, adding a Jest reporter for jUnit test results. This is needed because the CI needs XML files in xUnit format to track tests results across builds.

Besides that, we use a parallel stage to run unit tests in three platforms: Linux, Windows and MacOSX.

## Screenshots
Parallel execution of Windows, Linux and Mac
<img width="1434" alt="Screenshot 2019-10-23 at 15 04 31" src="https://user-images.githubusercontent.com/951580/67395582-8a966880-f5a6-11e9-80c8-4e9f8762e31e.png">

Tests results added to Jenkins
<img width="1436" alt="Screenshot 2019-10-23 at 15 06 09" src="https://user-images.githubusercontent.com/951580/67395682-b0bc0880-f5a6-11e9-8581-7b3c7ee00d5b.png">

## Author's checklist
- [x] New `npm run test:ci` command generates test results in xUnit format
- [x] Tested locally using Local Infra