### PR TITLE
Do not install packages if already present

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
   environment {
     REPO = 'ctags-langserver'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
+    JEST_JUNIT_OUTPUT_DIR="test-results"
     NODE_VERSION="10"
     YARN_GPG = 'no'
   }

--- a/.ci/scripts/darwin/run-yarn-tests.sh
+++ b/.ci/scripts/darwin/run-yarn-tests.sh
@@ -3,20 +3,43 @@ set -euxo pipefail
 
 NODE_VERSION=${1:?"Node version is required"}
 
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.0/install.sh | bash
+function install_nvm() {
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.0/install.sh | bash
 
-source "${NVM_DIR}/nvm.sh"
+    source "${NVM_DIR}/nvm.sh"
 
-nvm --version
+    nvm --version
+}
 
-nvm install ${NODE_VERSION}
+function install_node() {
+    nvm install ${NODE_VERSION}
 
-nvm use --delete-prefix ${NODE_VERSION}
+    nvm use --delete-prefix ${NODE_VERSION}
+}
 
-touch ~/.bashrc
+function install_yarn() {
+    touch ~/.bashrc
 
-curl -o- -L https://yarnpkg.com/install.sh | bash
+    curl -o- -L https://yarnpkg.com/install.sh | bash
+}
 
-yarn install
+function run_tests() {
+    yarn install
+    yarn test:ci
+}
 
-yarn test:ci
+function main() {
+    if ! [ -f "${HOME}/.nvm/nvm.sh" ]; then
+        install_nvm
+    fi
+
+    if ! [ -x "$(command -v node)" ]; then
+        install_node
+    fi
+
+    if ! [ -x "$(command -v yarn)" ]; then
+        install_yarn
+    fi
+}
+
+main "$@"

--- a/.ci/scripts/darwin/run-yarn-tests.sh
+++ b/.ci/scripts/darwin/run-yarn-tests.sh
@@ -13,8 +13,6 @@ function install_nvm() {
 
 function install_node() {
     nvm install ${NODE_VERSION}
-
-    nvm use --delete-prefix ${NODE_VERSION}
 }
 
 function install_yarn() {
@@ -37,9 +35,13 @@ function main() {
         install_node
     fi
 
+    nvm use --delete-prefix ${NODE_VERSION}
+
     if ! [ -x "$(command -v yarn)" ]; then
         install_yarn
     fi
+
+    run_tests
 }
 
 main "$@"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ctags-langserver
 
 [![Build Status](https://travis-ci.org/elastic/ctags-langserver.svg?branch=master)](https://travis-ci.org/elastic/ctags-langserver) [![Build Status](https://ci.appveyor.com/api/projects/status/github/elastic/ctags-langserver?branch=master&svg=true)]()
+[![Build Status](https://apm-ci.elastic.co/buildStatus/icon?job=code%2Fcode-ctags-langserver%2Fmaster)](https://apm-ci.elastic.co/job/code/job/code-ctags-langserver/job/master/)
 
 # Supported Protocol features
 

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
 		"compile": "tsc -b tsconfig.json",
 		"tslint": "tslint -c tslint.json -p .",
 		"test": "jest",
-		"test:ci": "JEST_JUNIT_OUTPUT_DIR=test-results jest --ci --reporters=default --reporters='jest-junit'",
-		"test:ci:windows": "set JEST_JUNIT_OUTPUT_DIR=test-results && jest --ci --reporters=default --reporters='jest-junit'",
+		"test:ci": "jest --ci --reporters=default --reporters='jest-junit'",
+		"test:ci:windows": "jest --ci --reporters=default --reporters='jest-junit'",
 		"clean": "rimraf lib",
 		"lint": "tslint -c ./tslint.json --project .",
 		"pub": "yarn clean && yarn build && yarn publish --access=public"


### PR DESCRIPTION
## What does this PR do?
It verifies that nvm, node and yarn are not already installed in the MacOSX build agents, which are not immutable

It also fixes the environment variables needed by [Jest xUnit reporter](https://www.npmjs.com/package/jest-junit) to define the location of the test results: here we moved the setting to the pipeline, as the npm scripts are mainly used by the CI. Therefore, windows execution will generate properly its test results file.
